### PR TITLE
Add `allow_issue_writing` input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this GitHub action will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- An input (`allow_issue_writing`) to choose if a GitHub issue should be raised or not.
+
 ### Changed
 - Update dependencies.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Make sure to checkout the repository (actions/checkout@v2) to provide the ZAP ru
 
 **Optional** Additional command lines options for the full scan script
 
+### `allow_issue_writing`
+
+**Optional** By default the action will file the report to the GitHub issue using the `issue_title` input.
+Set this to false if you don't want the issue to be created or updated.
+
 ### `issue_title`
 
 **Optional** The title for the GitHub issue to be created.

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'The action status will be set to fail if ZAP identifies any alerts during the full scan'
     required: false
     default: false
+  allow_issue_writing:
+    description: 'Whether Github issues should be created or not'
+    required: false
+    default: true
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -3808,9 +3808,14 @@ async function run() {
         let cmdOptions = core.getInput('cmd_options');
         let issueTitle = core.getInput('issue_title');
         let failAction = core.getInput('fail_action');
+        let allowIssueWriting = core.getInput('allow_issue_writing');
+        let createIssue = true;
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
             console.log('[WARNING]: \'fail_action\' action input should be either \'true\' or \'false\'');
+        }
+        if (String(allowIssueWriting).toLowerCase() === 'false') {
+            createIssue = false;
         }
 
         console.log('starting the program');
@@ -3845,7 +3850,7 @@ async function run() {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
-        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName);
+        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue);
     } catch (error) {
         core.setFailed(error.message);
     }
@@ -20354,10 +20359,15 @@ const _ = __webpack_require__(557);
 const actionHelper = __webpack_require__(174);
 
 let actionCommon = {
-    processReport: (async (token, workSpace, plugins, currentRunnerID, issueTitle, repoName) => {
+    processReport: (async (token, workSpace, plugins, currentRunnerID, issueTitle, repoName, allowIssueWriting = true) => {
         let jsonReportName = 'report_json.json';
         let mdReportName = 'report_md.md';
         let htmlReportName = 'report_html.html';
+
+        if (!allowIssueWriting) {
+            actionHelper.uploadArtifacts(workSpace, mdReportName, jsonReportName, htmlReportName);
+            return;
+        }
 
         let openIssue;
         let currentReport;

--- a/index.js
+++ b/index.js
@@ -21,9 +21,14 @@ async function run() {
         let cmdOptions = core.getInput('cmd_options');
         let issueTitle = core.getInput('issue_title');
         let failAction = core.getInput('fail_action');
+        let allowIssueWriting = core.getInput('allow_issue_writing');
+        let createIssue = true;
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
             console.log('[WARNING]: \'fail_action\' action input should be either \'true\' or \'false\'');
+        }
+        if (String(allowIssueWriting).toLowerCase() === 'false') {
+            createIssue = false;
         }
 
         console.log('starting the program');
@@ -58,7 +63,7 @@ async function run() {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
-        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName);
+        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue);
     } catch (error) {
         core.setFailed(error.message);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -766,9 +766,9 @@
       "dev": true
     },
     "@zaproxy/actions-common-scans": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@zaproxy/actions-common-scans/-/actions-common-scans-0.1.0.tgz",
-      "integrity": "sha512-yfXPuoNWMHQSfY3TII2rm/8NALCvGFn9lT5N/N5SzjuqVBrc6mO8dxgDJnWAdnKRgqTjWVOX8lBX2xziwmKm2A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zaproxy/actions-common-scans/-/actions-common-scans-0.2.0.tgz",
+      "integrity": "sha512-Xv7dYtNLtXCG2rPXzJa+iIkIqFPsrzcM2d2tWlx3taElz/7bRQqt04ZgBBA0m2W1Xh88QspZ3f49+2KRFwm9qw==",
       "requires": {
         "@actions/artifact": "^0.2.0",
         "@actions/core": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.0",
     "@actions/github": "^1.0.0",
-    "@zaproxy/actions-common-scans": "^0.1.0",
+    "@zaproxy/actions-common-scans": "^0.2.0",
     "adm-zip": "^0.4.14",
     "d3-dsv": "^1.2.0",
     "github-api": "^3.3.0",


### PR DESCRIPTION
This PR adds an `allow_issue_writing` input that will control the ability to open Github issues or not, in case some users do not want to use that feature. It still defaults to `true`. The implementation is similar to the one in the `action-baseline` package. Please go ahead and review it and merge it if you think it would add value to this project. Thanks!