### PR TITLE
Update names and default Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this GitHub action will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- The default Docker image was changed to `ghcr.io/zaproxy/zaproxy:stable`.
 
 ## [0.5.1] - 2023-07-05
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZAP Action Full Scan
 
-A GitHub Action for running the OWASP ZAP [Full Scan](https://www.zaproxy.org/docs/docker/full-scan/) to perform
+A GitHub Action for running the ZAP [Full Scan](https://www.zaproxy.org/docs/docker/full-scan/) to perform
 Dynamic Application Security Testing (DAST). 
 
 The ZAP full scan action runs the ZAP spider against the specified target (by default with no time limit) followed by an 
@@ -87,7 +87,7 @@ jobs:
         uses: zaproxy/action-full-scan@v0.5.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           target: 'https://www.zaproxy.org/'
           rules_file_name: '.zap/rules.tsv'
           cmd_options: '-a'
@@ -98,8 +98,6 @@ jobs:
 ZAP is internationalised and alert information is available in many languages.
 
 You can change the language used by this action by changing the locale via the `cmd_options` e.g.: `-z "-config view.locale=fr_FR"`
-
-This is currently only available with the `owasp/zap2docker-weekly` or `owasp/zap2docker-live` Docker images.
 
 See [https://github.com/zaproxy/zaproxy/tree/develop/zap/src/main/dist/lang](https://github.com/zaproxy/zaproxy/tree/develop/zap/src/main/dist/lang) for the full set of locales currently supported.
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'OWASP ZAP Full Scan'
-description: 'Scans the web application with the OWASP ZAP Full Scan'
+name: 'ZAP Full Scan'
+description: 'Scans the web application with the ZAP Full Scan'
 branding:
   icon: 'zap'
   color: 'blue'
@@ -17,7 +17,7 @@ inputs:
   docker_name:
     description: 'The Docker file to be executed'
     required: true
-    default: 'owasp/zap2docker-stable'
+    default: 'ghcr.io/zaproxy/zaproxy:stable'
   cmd_options:
     description: 'Additional command line options'
     required: false


### PR DESCRIPTION
Remove OWASP references.
Use Docker image from GHCR.
Remove outdated note in the readme.