### PR TITLE
Add artifact name as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Update Crowdin link.
 
+### Added
+ - An input (`artifact_name`) used to name the artifact that contains the ZAP reports. [#73](https://github.com/zaproxy/action-full-scan/pull/73)
+
 ## [0.6.0] - 2023-08-02
 ### Changed
 - The default Docker image was changed to `ghcr.io/zaproxy/zaproxy:stable`.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ You do not have to create a dedicated token. Make sure to use the GitHub's defau
 **Optional** By default ZAP Docker container will fail with an [exit code](https://github.com/zaproxy/zaproxy/blob/efb404d38280dc9ecf8f88c9b0c658385861bdcf/docker/zap-full-scan.py#L31), 
 if it identifies any alerts. Set this option to `true` if you want to fail the status of the GitHub Scan if ZAP identifies any alerts during the scan.
 
+### `artifact_name`
+
+**Optional** By default the full scan action will attach the report to the build with the name `zap_scan`. Set this to a different string to name it something else. Consult [GitHub's documentation](https://github.com/actions/toolkit/blob/main/packages/artifact/docs/additional-information.md#non-supported-characters) for which artifact names are allowed.
+
 ## Example usage
 
 ** Basic **

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: 'Whether Github issues should be created or not'
     required: false
     default: true
+  artifact_name:
+    description: 'The name of the artifact that contains the ZAP reports'
+    required: false
+    default: 'zap_scan'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -38341,6 +38341,7 @@ async function run() {
         let issueTitle = core.getInput('issue_title');
         let failAction = core.getInput('fail_action');
         let allowIssueWriting = core.getInput('allow_issue_writing');
+        let artifactName = core.getInput('artifact_name');
         let createIssue = true;
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
@@ -38348,6 +38349,11 @@ async function run() {
         }
         if (String(allowIssueWriting).toLowerCase() === 'false') {
             createIssue = false;
+        }
+
+        if (!artifactName) {
+            console.log('[WARNING]: \'artifact_name\' action input should not be empty. Setting it back to the default name.');
+            artifactName = 'zap_scan';
         }
 
         console.log('starting the program');
@@ -38386,7 +38392,7 @@ async function run() {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
-        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue);
+        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue, artifactName);
     } catch (error) {
         core.setFailed(error.message);
     }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ async function run() {
         let issueTitle = core.getInput('issue_title');
         let failAction = core.getInput('fail_action');
         let allowIssueWriting = core.getInput('allow_issue_writing');
+        let artifactName = core.getInput('artifact_name');
         let createIssue = true;
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
@@ -29,6 +30,11 @@ async function run() {
         }
         if (String(allowIssueWriting).toLowerCase() === 'false') {
             createIssue = false;
+        }
+
+        if (!artifactName) {
+            console.log('[WARNING]: \'artifact_name\' action input should not be empty. Setting it back to the default name.');
+            artifactName = 'zap_scan';
         }
 
         console.log('starting the program');
@@ -67,7 +73,7 @@ async function run() {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
-        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue);
+        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue, artifactName);
     } catch (error) {
         core.setFailed(error.message);
     }


### PR DESCRIPTION
Just copied from here https://github.com/zaproxy/action-baseline/blob/master/action.yml#L36-L39

This PR adds a new input parameter to the existing GitHub Action for running ZAP security scans. The new input parameter allows the user to specify the name of the artifact that contains the ZAP reports. If the artifact name is not specified, the action will use the default name. This feature improves the flexibility of the action and makes it easier to integrate with different workflows. Please review and merge if approved.