### PR TITLE
Pass ZAP auth env vars and release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this GitHub action will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.8.0] - 2023-10-31
+### Added
+- Support for authentication environment variables.
 
 ## [0.7.0] - 2023-08-24
 ### Fixed
@@ -55,7 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 First release to Marketplace.
 
-[Unreleased]: https://github.com/zaproxy/action-full-scan/compare/v0.7.0...HEAD
+[0.8.0]: https://github.com/zaproxy/action-full-scan/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/zaproxy/action-full-scan/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/zaproxy/action-full-scan/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/zaproxy/action-full-scan/compare/v0.5.0...v0.5.1

--- a/README.md
+++ b/README.md
@@ -62,13 +62,22 @@ if it identifies any alerts. Set this option to `true` if you want to fail the s
 
 **Optional** By default the full scan action will attach the report to the build with the name `zap_scan`. Set this to a different string to name it something else. Consult [GitHub's documentation](https://github.com/actions/toolkit/blob/main/packages/artifact/docs/additional-information.md#non-supported-characters) for which artifact names are allowed.
 
+## Environment variables
+
+If set, the following [ZAP authentication environment variables](https://www.zaproxy.org/docs/authentication/handling-auth-yourself/#authentication-env-vars)
+will be copied into the docker container:
+
+- `ZAP_AUTH_HEADER_VALUE`
+- `ZAP_AUTH_HEADER`
+- `ZAP_AUTH_HEADER_SITE`
+
 ## Example usage
 
 ** Basic **
 ```
 steps:
   - name: ZAP Scan
-    uses: zaproxy/action-full-scan@v0.7.0
+    uses: zaproxy/action-full-scan@v0.8.0
     with:
       target: 'https://www.zaproxy.org/'
 ```
@@ -88,7 +97,7 @@ jobs:
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.7.0
+        uses: zaproxy/action-full-scan@v0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'ghcr.io/zaproxy/zaproxy:stable'

--- a/dist/index.js
+++ b/dist/index.js
@@ -38369,7 +38369,7 @@ async function run() {
         await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
-        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
+        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE ` +
             `-t ${docker_name} zap-full-scan.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function run() {
         await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
-        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
+        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE ` +
             `-t ${docker_name} zap-full-scan.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {


### PR DESCRIPTION
Allow to do the scans authenticated with manual auth.
Same as zaproxy/action-api-scan#9.

Update changelog and readme for release.