### PR TITLE
feat: add min_level input to filter ZAP scan alerts by severity

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'The name of the artifact that contains the ZAP reports'
     required: false
     default: 'zap_scan'
+  min_level:
+    description: 'Minimum level to show in the ZAP report: PASS, IGNORE, INFO, WARN or FAIL'
+    required: false
+    default: ''
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -23,11 +23,13 @@ async function run() {
         let failAction = core.getInput('fail_action');
         let allowIssueWriting = core.getInput('allow_issue_writing');
         let artifactName = core.getInput('artifact_name');
+        let minLevel = core.getInput('min_level');
         let createIssue = true;
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
             console.log('[WARNING]: \'fail_action\' action input should be either \'true\' or \'false\'');
         }
+
         if (String(allowIssueWriting).toLowerCase() === 'false') {
             createIssue = false;
         }
@@ -35,6 +37,13 @@ async function run() {
         if (!artifactName) {
             console.log('[WARNING]: \'artifact_name\' action input should not be empty. Setting it back to the default name.');
             artifactName = 'zap_scan';
+        }
+
+        // Validate min_level input
+        const validLevels = ['PASS', 'IGNORE', 'INFO', 'WARN', 'FAIL'];
+        if (minLevel && !validLevels.includes(minLevel.toUpperCase())) {
+            console.log(`[WARNING]: 'min_level' must be one of: ${validLevels.join(', ')}. Ignoring invalid value.`);
+            minLevel = '';
         }
 
         console.log('starting the program');
@@ -47,10 +56,13 @@ async function run() {
 
         // Allow writing files from the Docker container.
         await exec.exec(`chmod a+w ${workspace}`);
-
         await exec.exec(`docker pull ${docker_name} -q`);
+
+        // Build -l flag only if a valid min_level was provided
+        const minLevelFlag = minLevel ? `-l ${minLevel.toUpperCase()}` : '';
+
         let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE ` +
-            `-t ${docker_name} zap-full-scan.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
+            `-t ${docker_name} zap-full-scan.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${minLevelFlag} ${cmdOptions}`);
 
         if (plugins.length !== 0) {
             command = command + ` -c ${rulesFileLocation}`
@@ -68,10 +80,11 @@ async function run() {
                 && String(failAction).toLowerCase() === 'true') {
                 console.log(`[info] By default ZAP Docker container will fail if it identifies any alerts during the scan!`);
                 core.setFailed('Scan action failed as ZAP has identified alerts, starting to analyze the results. ' + err.toString());
-            }else {
+            } else {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
+
         await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue, artifactName);
     } catch (error) {
         core.setFailed(error.message);


### PR DESCRIPTION
## Summary
Adds a new `min_level` input that allows users to filter ZAP scan alerts
by minimum severity level, reducing noise in GitHub issues created by the action.

## Problem
#9

Currently the action reports ALL alert levels including INFO and LOW findings.
This floods issue trackers with low-priority noise and makes it harder to focus
on critical vulnerabilities. Users have no way to say "only report WARN and above."

## Solution
The underlying `zap-full-scan.py` already supports a `-l` flag for minimum alert
level. This PR exposes that flag as a new optional `min_level` input and wires
it through to the ZAP Docker command.

## Changes
- `action.yml` — added `min_level` input (optional, defaults to `''`)
- `index.js` — reads input, validates against allowed levels, builds `-l` flag
- `dist/index.js` — rebuilt bundle

## Usage
```yaml
- name: ZAP Full Scan
  uses: zaproxy/action-full-scan@v0.11.0
  with:
    target: 'https://example.com'
    min_level: 'WARN'  # Only create issues for WARN and FAIL alerts
```

## Valid values
`PASS`, `IGNORE`, `INFO`, `WARN`, `FAIL`

Invalid values are ignored with a warning and the scan runs without the `-l` flag,
preserving existing behaviour.

## Testing
Validation logic tested locally:
- `WARN` → `-l WARN` appended to command 
- `fail` → `-l FAIL` (uppercased correctly) 
- `HIGH` → warning logged, flag ignored 
- `invalid` → warning logged, flag ignored 
- `''` → no flag added, existing behaviour preserved 